### PR TITLE
Fix docs build for docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 // Adapted from rustc's path_relative_from
 // https://github.com/rust-lang/rust/blob/e1d0de82cc40b666b88d4a6d2c9dcbc81d7ed27f/src/librustc_back/rpath.rs#L116-L158
 
+#![feature(doc_cfg)]
+
 use std::path::*;
 
 /// Construct a relative path from a provided base directory path to the provided path.


### PR DESCRIPTION
Fix #14 

Managed to reproduce the error from the build logs locally:
```
➜  pathdiff git:(master) cargo +nightly rustdoc --lib -Zrustdoc-map --all-features --config 'build.rustdocflags=["--cfg", "docsrs", "-Z", "unstable-options", "--emit=invocation-specific", "--resource-suffix", "-20241010-1.83.0-nightly-52fd99839", "--static-root-path", "/-/rustdoc.static/", "--cap-lints", "warn", "--extern-html-root-takes-precedence"]' --offline -Zunstable-options --config=doc.extern-map.registries.crates-io=\"https://docs.rs/{pkg_name}/{version}/x86_64-unknown-linux-gnu\" -Zrustdoc-scrape-examples -j6 --target x86_64-unknown-linux-gnu

warning: target filter specified, but no targets matched; this is a no-op
    Checking camino v1.1.9
 Documenting pathdiff v0.2.2 (/Users/t4lz/private-projects/pathdiff)
error[E0658]: `#[doc(cfg)]` is experimental
   --> src/lib.rs:118:24
    |
118 |     #[cfg_attr(docsrs, doc(cfg(feature = "camino")))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
    = note: this compiler was built on 2024-11-22; consider upgrading it if it is out of date

For more information about this error, try `rustc --explain E0658`.
error: could not document `pathdiff`
```

After adding the feature as suggested in the error:

```
➜  pathdiff git:(fix-docs-build) ✗ cargo +nightly rustdoc --lib -Zrustdoc-map --all-features --config 'build.rustdocflags=["--cfg", "docsrs", "-Z", "unstable-options", "--emit=invocation-specific", "--resource-suffix", "-20241010-1.83.0-nightly-52fd99839", "--static-root-path", "/-/rustdoc.static/", "--cap-lints", "warn", "--extern-html-root-takes-precedence"]' --offline -Zunstable-options --config=doc.extern-map.registries.crates-io=\"https://docs.rs/{pkg_name}/{version}/x86_64-unknown-linux-gnu\" -Zrustdoc-scrape-examples -j6 --target x86_64-unknown-linux-gnu

warning: target filter specified, but no targets matched; this is a no-op
 Documenting pathdiff v0.2.2 (/Users/t4lz/private-projects/pathdiff)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.84s
   Generated /Users/t4lz/private-projects/pathdiff/target/x86_64-unknown-linux-gnu/doc/pathdiff/index.html
```