### PR TITLE
Fix docs build for docs.rs by turning on feature only on docs.rs builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 // Adapted from rustc's path_relative_from
 // https://github.com/rust-lang/rust/blob/e1d0de82cc40b666b88d4a6d2c9dcbc81d7ed27f/src/librustc_back/rpath.rs#L116-L158
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use std::path::*;
 
 /// Construct a relative path from a provided base directory path to the provided path.


### PR DESCRIPTION
Another go at #14 

In my last PR I didn't think about the fact that with that approach the crate would only build on nightly.

With the new change in this PR the crate builds successfully on stable, and the docs build successfully with the command from the docs.rs build logs (which uses nightly).